### PR TITLE
Integrating `cibuildwheel`

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -1,0 +1,35 @@
+name: Build
+
+on: [push, pull_request]
+
+jobs:
+  build_wheels:
+    name: Build wheels on ${{ matrix.os }}
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [ubuntu-latest, windows-2019, macos-latest]
+
+    steps:
+      - uses: actions/checkout@v3
+        with:
+          submodules: recursive
+
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v2.9.0
+        env:
+            CIBW_BUILD: 'cp36-* cp37-* cp38-* cp39-* cp310-*'
+            CIBW_ARCHS_MACOS: "x86_64 arm64"
+            CIBW_PROJECT_REQUIRES_PYTHON: ">=3.7,<3.11"
+        #   CIBW_SKIP: "*-win32 *-manylinux_i686"
+        #   CIBW_SOME_OPTION: value
+        #    ...
+        # with:
+        #   package-dir: .
+        #   output-dir: wheelhouse
+        #   config-file: "{package}/pyproject.toml"
+
+      - uses: actions/upload-artifact@v3
+        with:
+          path: ./wheelhouse/*.whl
+

--- a/setup.py
+++ b/setup.py
@@ -47,8 +47,11 @@ class CMakeBuild(build_ext):
 
         if platform.system() == "Windows":
             cmake_args += ['-DCMAKE_LIBRARY_OUTPUT_DIRECTORY_{}={}'.format(cfg.upper(), extdir)]
+            cmake_args += (['-G','Visual Studio 16 2019'])
             if sys.maxsize > 2**32:
                 cmake_args += ['-A', 'x64']
+            else:
+                cmake_args += ['-A', 'Win32']
             build_args += ['--', '/m']
         else:
             cmake_args += ['-DCMAKE_BUILD_TYPE=' + cfg]


### PR DESCRIPTION
This Github Actions can help with building a binary distribution of `link-python`. I only had to do minor modifications in the build process + add a line to git clone recursively in the action itself. See [this file](https://github.com/pypa/cibuildwheel/blob/main/examples/github-deploy.yml) for going even further and deploying built wheels on Pypi automatically! :)